### PR TITLE
bump ghc-prim upper bound

### DIFF
--- a/quantification.cabal
+++ b/quantification.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 name: quantification
-version: 0.5.1
+version: 0.5.2
 synopsis: Rage against the quantification
 description: Data types and typeclasses to deal with universally and existentially quantified types
 homepage: https://github.com/andrewthad/quantification#readme
@@ -23,7 +23,7 @@ library
   build-depends:
       base >= 4.11.1 && < 5
     , binary >= 0.8 && < 0.10
-    , ghc-prim >= 0.5 && < 0.6
+    , ghc-prim >= 0.5 && < 0.7
     , hashable >= 1.2 && < 1.4
     , aeson >= 1.0 && < 1.5
     , text >= 1.0 && < 2.0


### PR DESCRIPTION
- allows quantification to be built with ghc 8.10.1
- no breaking changes in `ghc-prim` afaict from looking at the changelog